### PR TITLE
Rename package to schwabapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,15 +60,15 @@ The Schwab API Python Library offers a complete suite of trading and account man
 ### From PyPI (Recommended)
 
 ```bash
-pip install schwab
+pip install schwabapi
 ```
 
 ### From Source
 
 1. Clone the repository:
 ```bash
-git clone https://github.com/ibouazizi/schwab.git
-cd schwab
+git clone https://github.com/ibouazizi/schwabapi.git
+cd schwabapi
 ```
 
 2. Install in development mode:
@@ -80,8 +80,8 @@ pip install -e .
 
 1. Clone the repository:
 ```bash
-git clone https://github.com/ibouazizi/schwab.git
-cd schwab
+git clone https://github.com/ibouazizi/schwabapi.git
+cd schwabapi
 ```
 
 2. Install build dependencies:
@@ -100,7 +100,7 @@ This will create two files in the `dist` directory:
 
 4. Install the built package:
 ```bash
-pip install dist/schwab_api-*.whl
+pip install dist/schwabapi-*.whl
 ```
 
 ### Development Installation

--- a/README.md
+++ b/README.md
@@ -60,15 +60,15 @@ The Schwab API Python Library offers a complete suite of trading and account man
 ### From PyPI (Recommended)
 
 ```bash
-pip install schwab-api
+pip install schwab
 ```
 
 ### From Source
 
 1. Clone the repository:
 ```bash
-git clone https://github.com/ibouazizi/schwab-api.git
-cd schwab-api
+git clone https://github.com/ibouazizi/schwab.git
+cd schwab
 ```
 
 2. Install in development mode:
@@ -80,8 +80,8 @@ pip install -e .
 
 1. Clone the repository:
 ```bash
-git clone https://github.com/ibouazizi/schwab-api.git
-cd schwab-api
+git clone https://github.com/ibouazizi/schwab.git
+cd schwab
 ```
 
 2. Install build dependencies:

--- a/docs/API.md
+++ b/docs/API.md
@@ -17,13 +17,13 @@ This API documentation is provided for informational purposes only. Before using
 
 ### From PyPI
 ```bash
-pip install schwab
+pip install schwabapi
 ```
 
 ### From Source
 ```bash
-git clone https://github.com/ibouazizi/schwab.git
-cd schwab
+git clone https://github.com/ibouazizi/schwabapi.git
+cd schwabapi
 pip install -e .
 ```
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -17,13 +17,13 @@ This API documentation is provided for informational purposes only. Before using
 
 ### From PyPI
 ```bash
-pip install schwab-api
+pip install schwab
 ```
 
 ### From Source
 ```bash
-git clone https://github.com/ibouazizi/schwab-api.git
-cd schwab-api
+git clone https://github.com/ibouazizi/schwab.git
+cd schwab
 pip install -e .
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -7,14 +7,14 @@ with open("requirements.txt", "r", encoding="utf-8") as fh:
     requirements = [line.strip() for line in fh if line.strip() and not line.startswith("#")]
 
 setup(
-    name="schwab",
+    name="schwabapi",
     version="0.1.0",
     author="Iheb Bouazizi",
     author_email="iheb.bouazizi@gmail.com",
     description="A Python library for interacting with Charles Schwab's Trading API",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/ibouazizi/schwab",
+    url="https://github.com/ibouazizi/schwabapi",
     packages=find_packages(),
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -7,14 +7,14 @@ with open("requirements.txt", "r", encoding="utf-8") as fh:
     requirements = [line.strip() for line in fh if line.strip() and not line.startswith("#")]
 
 setup(
-    name="schwab-api",
+    name="schwab",
     version="0.1.0",
     author="Iheb Bouazizi",
     author_email="iheb.bouazizi@gmail.com",
     description="A Python library for interacting with Charles Schwab's Trading API",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/ibouazizi/schwab-api",
+    url="https://github.com/ibouazizi/schwab",
     packages=find_packages(),
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
This PR renames the package to schwabapi for better naming consistency:

- Update package name in setup.py
- Update repository URLs in documentation
- Update installation instructions in README.md and API.md

After this change is merged, the repository should also be renamed from schwab-api to schwabapi.